### PR TITLE
vanilla jsx runtime

### DIFF
--- a/internal/islands/client/jsx.ts
+++ b/internal/islands/client/jsx.ts
@@ -1,0 +1,25 @@
+type BaseProps = Record<string, any>;
+
+export function jsx(el: string, props: BaseProps | null): string
+export function jsx<P extends BaseProps>(el: (props: P) => string, props: P): string
+export function jsx(el: string | Function, props: BaseProps | null): string {
+  if (typeof el === "function") return el(props);
+  let { children, ...attrs } = props || {};
+
+  let attributes = Object
+    .entries(attrs)
+    .map(([k, v]) => `${k}="${v}"`)
+    .join(" ");
+
+  let innerHtml = Array.isArray(children) ? children.join("\n") : String(children);
+  return `<${el} ${attributes}>${innerHtml}</${el}>`
+}
+
+export function Fragment(props: BaseProps) {
+  return props.children;
+}
+
+export {
+  jsx as jsxs,
+  jsx as jsxDEV,
+}

--- a/internal/islands/islands.go
+++ b/internal/islands/islands.go
@@ -61,6 +61,9 @@ var (
 	//go:embed client/runtime.ts
 	sietchRuntimeSrc string
 
+	//go:embed client/jsx.ts
+	sietchJsxSrc string
+
 	// It's significantly faster to have one isolate than to create a context for
 	// each evaluation.
 	iso = v8go.NewIsolate()
@@ -107,6 +110,15 @@ func Render(opts RenderOptions) (map[string]string, error) {
 			islandsFrameworkPlugin(islandsPluginOptions{
 				resolveDir: opts.ResolveDir,
 				frameworks: opts.Frameworks,
+			}),
+			virtualModulesPlugin(virtualModulesConfig{
+				filter: `^sietch:`,
+				modules: map[string]api.OnLoadResult{
+					"sietch:jsx/jsx-runtime": {
+						Contents: &sietchJsxSrc,
+						Loader:   api.LoaderTS,
+					},
+				},
 			}),
 		},
 	})
@@ -255,6 +267,10 @@ func Bundle(opts BundleOptions) (map[string]*BundleResult, error) {
 			virtualModulesPlugin(virtualModulesConfig{
 				filter: `^sietch:`,
 				modules: map[string]api.OnLoadResult{
+					"sietch:jsx/jsx-runtime": {
+						Contents: &sietchJsxSrc,
+						Loader:   api.LoaderTS,
+					},
 					"sietch:runtime": {
 						Contents: &sietchRuntimeSrc,
 						Loader:   api.LoaderTS,


### PR DESCRIPTION
Little experiment to support JSX syntax in vanilla components. Marginally safer than interpolating HTML directly and supports a primitive version of components, but otherwise, mostly just fun to see that it works.

```ts
/** @jsxImportSource sietch:jsx */

export function render(props): string {
  return (
    <h1 id={props.id}>Hello</h1>
  )
}

export function hydrate(props, element) {
  element.style.color = "red";
}
```